### PR TITLE
toJSON() -> toDesign()

### DIFF
--- a/src/access.js
+++ b/src/access.js
@@ -14,6 +14,8 @@ export default class Access {
 			db = db.database;
 		}
 
+		// list of write operations on the design
+		this.operations = [];
 		// are we talking directly to CouchDB?
 		// this dictates whether or not we can write the access document
 		this.remote = db && db.adapter === "http";
@@ -21,8 +23,6 @@ export default class Access {
 		this.database = db;
 		// holds a copy of the current design doc
 		this.design = this.setDesign(design);
-		// list of write operations on the design
-		this.operations = [];
 	}
 
 	clone() {
@@ -230,9 +230,7 @@ export default class Access {
 	_play(op) {
 		// loop through operations
 		if (isArray(op)) {
-			op.forEach(function(o) {
-				this._play(o, true);
-			}, this);
+			op.forEach((o) => this._play(o, true));
 		}
 
 		// only apply datacore operations
@@ -243,9 +241,7 @@ export default class Access {
 
 	static play(security, design, op) {
 		if (isArray(op)) {
-			op.forEach(function(o) {
-				Access.play(security, design, o);
-			});
+			op.forEach((o) => Access.play(security, design, o));
 			return;
 		}
 

--- a/src/access.js
+++ b/src/access.js
@@ -60,9 +60,7 @@ export default class Access {
 
 	addLevel(name, before) {
 		if (isArray(name)) {
-			name.forEach(function(n) {
-				this.addLevel(n, before);
-			}, this);
+			name.forEach((n) => this.addLevel(n, before));
 			return this;
 		}
 
@@ -80,7 +78,7 @@ export default class Access {
 
 	removeLevel(name) {
 		if (isArray(name)) {
-			name.forEach(this.removeLevel, this);
+			name.forEach((n) => this.removeLevel(n));
 			return this;
 		}
 
@@ -98,16 +96,12 @@ export default class Access {
 		}
 
 		if (isArray(item)) {
-			item.forEach(function(i) {
-				this.setLevel(list, i, level);
-			}, this);
+			item.forEach((i) => this.setLevel(list, i, level));
 			return this;
 		}
 
 		if (typeof item === "object" && item != null && level == null) {
-			forEach(item, function(r, i) {
-				this.setLevel(list, i, r);
-			}, this);
+			forEach(item, (r, i) => this.setLevel(list, i, r));
 			return this;
 		}
 
@@ -272,7 +266,7 @@ export default class Access {
 		if (!save) {
 			save = this._deferral = {};
 			let clean = () => delete this._deferral;
-			save.promise = new Promise(function(resolve, reject) {
+			save.promise = new Promise((resolve, reject) => {
 				save.resolve = resolve;
 				save.reject = reject;
 			}).then(clean, (e) => {

--- a/src/access.js
+++ b/src/access.js
@@ -10,8 +10,8 @@ const {Security} = securityPlugin;
 export default class Access {
 	constructor(db, design) {
 		if (db instanceof Access) {
-			design = db.toJSON();
-			db = this.database;
+			design = db.toDesign();
+			db = db.database;
 		}
 
 		// are we talking directly to CouchDB?
@@ -20,7 +20,7 @@ export default class Access {
 		// db to get and put with
 		this.database = db;
 		// holds a copy of the current design doc
-		this.design = Design.parse(design);
+		this.design = this.setDesign(design);
 		// list of write operations on the design
 		this.operations = [];
 	}
@@ -49,7 +49,7 @@ export default class Access {
 	}
 
 	setDesign(doc) {
-		if (doc instanceof Access) doc = doc.toJSON();
+		if (doc instanceof Access) doc = doc.toDesign();
 		this._reset(Design.parse(doc));
 		return this;
 	}
@@ -260,6 +260,13 @@ export default class Access {
 	}
 
 	toJSON() {
+		return {
+			private: this.private,
+			levels: this.levels
+		};
+	}
+
+	toDesign() {
 		return Design.compile(this.design);
 	}
 

--- a/src/access.js
+++ b/src/access.js
@@ -21,8 +21,8 @@ export default class Access {
 		this.remote = db && db.adapter === "http";
 		// db to get and put with
 		this.database = db;
-		// holds a copy of the current design doc
-		this.design = this.setDesign(design);
+		// set the current design
+		this.setDesign(design);
 	}
 
 	clone() {

--- a/src/design.js
+++ b/src/design.js
@@ -39,6 +39,8 @@ const Design = { // jshint ignore:line
 	},
 	levels: {
 		parse: function(src) {
+			if (isArray(src)) return src;
+
 			var levels = Design.extract(src, "levels");
 			if (!levels) return [];
 
@@ -65,7 +67,9 @@ const Design = { // jshint ignore:line
 		parse: function(validators) {
 			if (!validators) return {};
 			return reduce(validators, function(v, f, n) {
-				v[n] = Design.unexportify(f);
+				v[n] = typeof f === "function" ? f :
+					typeof f === "string" ? Design.unexportify(f) : null;
+					
 				return v;
 			}, {});
 		},

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 import test from "tape";
 import PouchDB from "pouchdb";
 import accessPlugin from "pouchdb-access";
+import {Security} from "pouchdb-security-helper";
 
 PouchDB.plugin(accessPlugin);
 
@@ -11,4 +12,21 @@ test("access() method returns an access object", (t) => {
 
 	t.ok(access, "returns access object");
 	t.equals(access.remote, false, "access is not remote");
+});
+
+test("parses simplified access info", (t) => {
+	t.plan(1);
+	let db = new PouchDB("tmpdb", { adapter: "memory" });
+
+	let simple = {
+		private: true,
+		levels: [{
+			name: "test",
+			sec: new Security.Level()
+		}]
+	};
+
+	let access = db.access(simple);
+
+	t.deepEquals(access.toJSON(), simple, "set access to the original simplified version");
 });


### PR DESCRIPTION
BREAKING CHANGE: `toJSON()` returns a simple version of the access information. `toDesign()` now does what `toJSON()` did.
